### PR TITLE
InstrumentedRoundTripper handles cancelable transports

### DIFF
--- a/dropsonde_test.go
+++ b/dropsonde_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Autowire", func() {
 	Describe("Initialize", func() {
 		It("resets the HTTP default transport to be instrumented", func() {
 			dropsonde.InitializeWithEmitter(&dropsonde.NullEventEmitter{})
-			Expect(reflect.TypeOf(http.DefaultTransport).Elem().Name()).To(Equal("instrumentedRoundTripper"))
+			Expect(reflect.TypeOf(http.DefaultTransport).Elem().Name()).To(Equal("instrumentedCancelableRoundTripper"))
 		})
 	})
 


### PR DESCRIPTION
This change allows instrumenting a request made with an http.Client that
has a Timeout set.

Previously, an error would occur when instrumenting an http.Client with
a Timeout set. This is because the instrumented round tripper didn't
implement CancelRequest even when the underlying transport did. This
causes a runtime error when a request is made with the client.

Signed-off-by: Atul Kshirsagar <atul.kshirsagar@gmail.com>