### PR TITLE
Corrected import path of proto package

### DIFF
--- a/control/controlmessage.pb.go
+++ b/control/controlmessage.pb.go
@@ -15,7 +15,7 @@ It has these top-level messages:
 */
 package control
 
-import proto "code.google.com/p/gogoprotobuf/proto"
+import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/control/heartbeatrequest.pb.go
+++ b/control/heartbeatrequest.pb.go
@@ -4,7 +4,7 @@
 
 package control
 
-import proto "code.google.com/p/gogoprotobuf/proto"
+import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/control/uuid.pb.go
+++ b/control/uuid.pb.go
@@ -4,7 +4,7 @@
 
 package control
 
-import proto "code.google.com/p/gogoprotobuf/proto"
+import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/dropsonde_marshaller/dropsonde_marshaller.go
+++ b/dropsonde_marshaller/dropsonde_marshaller.go
@@ -16,11 +16,11 @@
 package dropsonde_marshaller
 
 import (
-	"code.google.com/p/gogoprotobuf/proto"
 	"github.com/cloudfoundry/dropsonde/events"
 	"github.com/cloudfoundry/gosteno"
 	"github.com/cloudfoundry/loggregatorlib/cfcomponent/instrumentation"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/gogo/protobuf/proto"
 	"sync/atomic"
 	"unicode"
 )

--- a/dropsonde_marshaller/dropsonde_marshaller_test.go
+++ b/dropsonde_marshaller/dropsonde_marshaller_test.go
@@ -1,12 +1,12 @@
 package dropsonde_marshaller_test
 
 import (
-	"code.google.com/p/gogoprotobuf/proto"
 	"github.com/cloudfoundry/dropsonde/dropsonde_marshaller"
 	"github.com/cloudfoundry/dropsonde/events"
 	"github.com/cloudfoundry/dropsonde/factories"
 	"github.com/cloudfoundry/loggregatorlib/cfcomponent/instrumentation/testhelpers"
 	"github.com/cloudfoundry/loggregatorlib/loggertesthelper"
+	"github.com/gogo/protobuf/proto"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/dropsonde_test.go
+++ b/dropsonde_test.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"time"
 	"reflect"
+	"time"
 
-	"code.google.com/p/gogoprotobuf/proto"
 	"github.com/cloudfoundry/dropsonde"
 	"github.com/cloudfoundry/dropsonde/control"
 	"github.com/cloudfoundry/dropsonde/events"
 	"github.com/cloudfoundry/dropsonde/factories"
+	"github.com/gogo/protobuf/proto"
 	uuid "github.com/nu7hatch/gouuid"
 
 	. "github.com/onsi/ginkgo"

--- a/dropsonde_unmarshaller/dropsonde_unmarshaller.go
+++ b/dropsonde_unmarshaller/dropsonde_unmarshaller.go
@@ -16,11 +16,11 @@
 package dropsonde_unmarshaller
 
 import (
-	"code.google.com/p/gogoprotobuf/proto"
 	"github.com/cloudfoundry/dropsonde/events"
 	"github.com/cloudfoundry/gosteno"
 	"github.com/cloudfoundry/loggregatorlib/cfcomponent/instrumentation"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/gogo/protobuf/proto"
 	"sync"
 	"sync/atomic"
 	"unicode"

--- a/dropsonde_unmarshaller/dropsonde_unmarshaller_test.go
+++ b/dropsonde_unmarshaller/dropsonde_unmarshaller_test.go
@@ -1,13 +1,13 @@
 package dropsonde_unmarshaller_test
 
 import (
-	"code.google.com/p/gogoprotobuf/proto"
 	"github.com/cloudfoundry/dropsonde/dropsonde_unmarshaller"
 	"github.com/cloudfoundry/dropsonde/events"
 	"github.com/cloudfoundry/dropsonde/factories"
 	"github.com/cloudfoundry/loggregatorlib/cfcomponent/instrumentation"
 	"github.com/cloudfoundry/loggregatorlib/cfcomponent/instrumentation/testhelpers"
 	"github.com/cloudfoundry/loggregatorlib/loggertesthelper"
+	"github.com/gogo/protobuf/proto"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/emitter/event_emitter.go
+++ b/emitter/event_emitter.go
@@ -1,9 +1,9 @@
 package emitter
 
 import (
-	"code.google.com/p/gogoprotobuf/proto"
 	"fmt"
 	"github.com/cloudfoundry/dropsonde/events"
+	"github.com/gogo/protobuf/proto"
 )
 
 type EventEmitter interface {

--- a/emitter/event_emitter_test.go
+++ b/emitter/event_emitter_test.go
@@ -1,11 +1,11 @@
 package emitter_test
 
 import (
-	"code.google.com/p/gogoprotobuf/proto"
 	"github.com/cloudfoundry/dropsonde/emitter"
 	"github.com/cloudfoundry/dropsonde/emitter/fake"
 	"github.com/cloudfoundry/dropsonde/events"
 	"github.com/cloudfoundry/dropsonde/factories"
+	"github.com/gogo/protobuf/proto"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/emitter/event_formatter.go
+++ b/emitter/event_formatter.go
@@ -1,9 +1,9 @@
 package emitter
 
 import (
-	"code.google.com/p/gogoprotobuf/proto"
 	"errors"
 	"github.com/cloudfoundry/dropsonde/events"
+	"github.com/gogo/protobuf/proto"
 	"time"
 )
 

--- a/emitter/event_formatter_test.go
+++ b/emitter/event_formatter_test.go
@@ -5,9 +5,9 @@ import (
 
 	"time"
 
-	"code.google.com/p/gogoprotobuf/proto"
 	"github.com/cloudfoundry/dropsonde/events"
 	"github.com/cloudfoundry/dropsonde/factories"
+	"github.com/gogo/protobuf/proto"
 	uuid "github.com/nu7hatch/gouuid"
 
 	. "github.com/onsi/ginkgo"

--- a/emitter/heartbeat_responder.go
+++ b/emitter/heartbeat_responder.go
@@ -5,9 +5,9 @@ import (
 	"runtime"
 	"sync"
 
-	"code.google.com/p/gogoprotobuf/proto"
 	"github.com/cloudfoundry/dropsonde/control"
 	"github.com/cloudfoundry/dropsonde/events"
+	"github.com/gogo/protobuf/proto"
 )
 
 type heartbeatResponder struct {

--- a/emitter/heartbeat_responder_test.go
+++ b/emitter/heartbeat_responder_test.go
@@ -8,12 +8,12 @@ import (
 
 	uuid "github.com/nu7hatch/gouuid"
 
-	"code.google.com/p/gogoprotobuf/proto"
 	"github.com/cloudfoundry/dropsonde/control"
 	"github.com/cloudfoundry/dropsonde/emitter"
 	"github.com/cloudfoundry/dropsonde/emitter/fake"
 	"github.com/cloudfoundry/dropsonde/events"
 	"github.com/cloudfoundry/dropsonde/factories"
+	"github.com/gogo/protobuf/proto"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/emitter/logemitter/emit.go
+++ b/emitter/logemitter/emit.go
@@ -1,12 +1,12 @@
 package logemitter
 
 import (
-	"code.google.com/p/gogoprotobuf/proto"
 	"errors"
 	"github.com/cloudfoundry/dropsonde/events"
 	"github.com/cloudfoundry/loggregatorlib/cfcomponent/generic_logger"
 	"github.com/cloudfoundry/loggregatorlib/loggregatorclient"
 	"github.com/cloudfoundry/loggregatorlib/logmessage"
+	"github.com/gogo/protobuf/proto"
 	"os"
 	"strings"
 	"time"

--- a/emitter/logemitter/emit_test.go
+++ b/emitter/logemitter/emit_test.go
@@ -1,10 +1,10 @@
 package logemitter_test
 
 import (
-	"code.google.com/p/gogoprotobuf/proto"
 	. "github.com/cloudfoundry/dropsonde/emitter/logemitter"
 	"github.com/cloudfoundry/dropsonde/emitter/logemitter/testhelpers"
 	"github.com/cloudfoundry/loggregatorlib/logmessage"
+	"github.com/gogo/protobuf/proto"
 	"log"
 	"os"
 	"strings"

--- a/emitter/logemitter/testhelpers/logmessage_testhelper.go
+++ b/emitter/logemitter/testhelpers/logmessage_testhelper.go
@@ -1,8 +1,8 @@
 package testhelpers
 
 import (
-	"code.google.com/p/gogoprotobuf/proto"
 	"github.com/cloudfoundry/dropsonde/events"
+	"github.com/gogo/protobuf/proto"
 	"time"
 )
 

--- a/emitter/udp_emitter.go
+++ b/emitter/udp_emitter.go
@@ -1,8 +1,8 @@
 package emitter
 
 import (
-	"code.google.com/p/gogoprotobuf/proto"
 	"github.com/cloudfoundry/dropsonde/control"
+	"github.com/gogo/protobuf/proto"
 	"net"
 )
 

--- a/emitter/udp_emitter_test.go
+++ b/emitter/udp_emitter_test.go
@@ -4,10 +4,10 @@ import (
 	"net"
 	"sync"
 
-	"code.google.com/p/gogoprotobuf/proto"
 	"github.com/cloudfoundry/dropsonde/control"
 	"github.com/cloudfoundry/dropsonde/emitter"
 	"github.com/cloudfoundry/dropsonde/factories"
+	"github.com/gogo/protobuf/proto"
 	uuid "github.com/nu7hatch/gouuid"
 
 	. "github.com/onsi/ginkgo"

--- a/envelope_extensions/envelope_extensions_test.go
+++ b/envelope_extensions/envelope_extensions_test.go
@@ -1,9 +1,9 @@
 package envelope_extensions_test
 
 import (
-	"code.google.com/p/gogoprotobuf/proto"
 	"github.com/cloudfoundry/dropsonde/envelope_extensions"
 	"github.com/cloudfoundry/dropsonde/events"
+	"github.com/gogo/protobuf/proto"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/events/envelope.pb.go
+++ b/events/envelope.pb.go
@@ -19,7 +19,7 @@ It has these top-level messages:
 */
 package events
 
-import proto "code.google.com/p/gogoprotobuf/proto"
+import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/events/error.pb.go
+++ b/events/error.pb.go
@@ -4,7 +4,7 @@
 
 package events
 
-import proto "code.google.com/p/gogoprotobuf/proto"
+import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/events/heartbeat.pb.go
+++ b/events/heartbeat.pb.go
@@ -4,7 +4,7 @@
 
 package events
 
-import proto "code.google.com/p/gogoprotobuf/proto"
+import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/events/http.pb.go
+++ b/events/http.pb.go
@@ -4,7 +4,7 @@
 
 package events
 
-import proto "code.google.com/p/gogoprotobuf/proto"
+import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/events/log.pb.go
+++ b/events/log.pb.go
@@ -4,7 +4,7 @@
 
 package events
 
-import proto "code.google.com/p/gogoprotobuf/proto"
+import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/events/metric.pb.go
+++ b/events/metric.pb.go
@@ -4,7 +4,7 @@
 
 package events
 
-import proto "code.google.com/p/gogoprotobuf/proto"
+import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/events/uuid.pb.go
+++ b/events/uuid.pb.go
@@ -4,7 +4,7 @@
 
 package events
 
-import proto "code.google.com/p/gogoprotobuf/proto"
+import proto "github.com/gogo/protobuf/proto"
 import math "math"
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/factories/factories.go
+++ b/factories/factories.go
@@ -1,11 +1,11 @@
 package factories
 
 import (
-	"code.google.com/p/gogoprotobuf/proto"
 	"encoding/binary"
 	"fmt"
 	"github.com/cloudfoundry/dropsonde/control"
 	"github.com/cloudfoundry/dropsonde/events"
+	"github.com/gogo/protobuf/proto"
 	uuid "github.com/nu7hatch/gouuid"
 	"net/http"
 	"strconv"

--- a/factories/factories_test.go
+++ b/factories/factories_test.go
@@ -5,9 +5,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"code.google.com/p/gogoprotobuf/proto"
 	"github.com/cloudfoundry/dropsonde/events"
 	"github.com/cloudfoundry/dropsonde/factories"
+	"github.com/gogo/protobuf/proto"
 	"net/http"
 )
 

--- a/integration_test/dropsonde_end_to_end_test.go
+++ b/integration_test/dropsonde_end_to_end_test.go
@@ -1,7 +1,6 @@
 package integration_test
 
 import (
-	"code.google.com/p/gogoprotobuf/proto"
 	"fmt"
 	"github.com/cloudfoundry/dropsonde"
 	"github.com/cloudfoundry/dropsonde/control"
@@ -9,6 +8,7 @@ import (
 	"github.com/cloudfoundry/dropsonde/factories"
 	"github.com/cloudfoundry/dropsonde/metric_sender"
 	"github.com/cloudfoundry/dropsonde/metrics"
+	"github.com/gogo/protobuf/proto"
 	uuid "github.com/nu7hatch/gouuid"
 
 	. "github.com/onsi/ginkgo"

--- a/log_sender/log_sender.go
+++ b/log_sender/log_sender.go
@@ -2,10 +2,10 @@ package log_sender
 
 import (
 	"bufio"
-	"code.google.com/p/gogoprotobuf/proto"
 	"github.com/cloudfoundry/dropsonde/emitter"
 	"github.com/cloudfoundry/dropsonde/events"
 	"github.com/cloudfoundry/gosteno"
+	"github.com/gogo/protobuf/proto"
 	"io"
 	"strings"
 	"time"

--- a/runtime_stats/runtime_stats.go
+++ b/runtime_stats/runtime_stats.go
@@ -1,9 +1,9 @@
 package runtime_stats
 
 import (
-	"code.google.com/p/gogoprotobuf/proto"
 	"github.com/cloudfoundry/dropsonde/emitter"
 	"github.com/cloudfoundry/dropsonde/events"
+	"github.com/gogo/protobuf/proto"
 	"log"
 	"runtime"
 	"time"

--- a/runtime_stats/runtime_stats_test.go
+++ b/runtime_stats/runtime_stats_test.go
@@ -3,10 +3,10 @@ package runtime_stats_test
 import (
 	"github.com/cloudfoundry/dropsonde/runtime_stats"
 
-	"code.google.com/p/gogoprotobuf/proto"
 	"errors"
 	"github.com/cloudfoundry/dropsonde/emitter/fake"
 	"github.com/cloudfoundry/dropsonde/events"
+	"github.com/gogo/protobuf/proto"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"log"


### PR DESCRIPTION
proto package is moved from code.google.com/p/gogoprotobuf/proto to github.com/gogo/protobuf/proto

The old path https://code.google.com/p/gogoprotobuf/ is no more available

All other packages which import proto might need to do the same shanges