### PR TITLE
Added HasValue to FakeMetricSender

### DIFF
--- a/metric_sender/fake/fake_metric_sender.go
+++ b/metric_sender/fake/fake_metric_sender.go
@@ -64,6 +64,14 @@ func (fms *FakeMetricSender) SendContainerMetric(applicationId string, instanceI
 	return nil
 }
 
+func (fms *FakeMetricSender) HasValue(name string) bool {
+	fms.RLock()
+	defer fms.RUnlock()
+
+	_, exists := fms.values[name]
+	return exists
+}
+
 func (fms *FakeMetricSender) GetValue(name string) Metric {
 	fms.RLock()
 	defer fms.RUnlock()


### PR DESCRIPTION
We have a situation in our tests where we want to differentiate between a metric being sent (but having the default value) and the same metric not being sent at all.

To fix this, we added a HasValue() method on the FakeMetricSender.