### PR TITLE
feat: expose BatchCounter for MetricBatcher

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,18 +1,18 @@
 // Package metrics provides a simple API for sending value and counter metrics
 // through the dropsonde system.
 //
-// Use
+// # Use
 //
 // See the documentation for package dropsonde for configuration details.
 //
 // Importing package dropsonde and initializing will initial this package.
 // To send metrics use
 //
-//		metrics.SendValue(name, value, unit)
+//	metrics.SendValue(name, value, unit)
 //
 // for sending known quantities, and
 //
-//		metrics.IncrementCounter(name)
+//	metrics.IncrementCounter(name)
 //
 // to increment a counter. (Note that the value of the counter is maintained by
 // the receiver of the counter events, not the application that includes this
@@ -21,6 +21,7 @@ package metrics
 
 import (
 	"github.com/cloudfoundry/dropsonde/metric_sender"
+	"github.com/cloudfoundry/dropsonde/metricbatcher"
 	"github.com/cloudfoundry/sonde-go/events"
 )
 
@@ -52,6 +53,7 @@ type MetricBatcher interface {
 	BatchIncrementCounter(name string)
 	BatchAddCounter(name string, delta uint64)
 	Close()
+	BatchCounter(name string) metricbatcher.BatchCounterChainer
 }
 
 // Initialize prepares the metrics package for use with the automatic Emitter.

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -142,4 +142,12 @@ var _ = Describe("Metrics", func() {
 			Consistently(newMetricBatcher.CloseCalled).ShouldNot(BeCalled())
 		})
 	})
+
+	Context("BatchCounter", func() {
+		It("gets a name", func() {
+			metricBatcher.BatchCounterOutput.Ret0 <- nil
+			metricBatcher.BatchCounter("test")
+			Eventually(metricBatcher.BatchCounterInput).Should(BeCalled(With("test")))
+		})
+	})
 })

--- a/metrics/mock_metric_batcher_test.go
+++ b/metrics/mock_metric_batcher_test.go
@@ -5,6 +5,10 @@
 
 package metrics_test
 
+import (
+	"github.com/cloudfoundry/dropsonde/metricbatcher"
+)
+
 type mockMetricBatcher struct {
 	BatchIncrementCounterCalled chan bool
 	BatchIncrementCounterInput  struct {
@@ -15,7 +19,14 @@ type mockMetricBatcher struct {
 		Name  chan string
 		Delta chan uint64
 	}
-	CloseCalled chan bool
+	CloseCalled        chan bool
+	BatchCounterCalled chan bool
+	BatchCounterInput  struct {
+		Name chan string
+	}
+	BatchCounterOutput struct {
+		Ret0 chan metricbatcher.BatchCounterChainer
+	}
 }
 
 func newMockMetricBatcher() *mockMetricBatcher {
@@ -26,6 +37,9 @@ func newMockMetricBatcher() *mockMetricBatcher {
 	m.BatchAddCounterInput.Name = make(chan string, 100)
 	m.BatchAddCounterInput.Delta = make(chan uint64, 100)
 	m.CloseCalled = make(chan bool, 100)
+	m.BatchCounterCalled = make(chan bool, 100)
+	m.BatchCounterInput.Name = make(chan string, 100)
+	m.BatchCounterOutput.Ret0 = make(chan metricbatcher.BatchCounterChainer, 100)
 	return m
 }
 func (m *mockMetricBatcher) BatchIncrementCounter(name string) {
@@ -39,4 +53,49 @@ func (m *mockMetricBatcher) BatchAddCounter(name string, delta uint64) {
 }
 func (m *mockMetricBatcher) Close() {
 	m.CloseCalled <- true
+}
+func (m *mockMetricBatcher) BatchCounter(name string) metricbatcher.BatchCounterChainer {
+	m.BatchCounterCalled <- true
+	m.BatchCounterInput.Name <- name
+	return <-m.BatchCounterOutput.Ret0
+}
+
+type mockBatchCounterChainer struct {
+	SetTagCalled chan bool
+	SetTagInput  struct {
+		Key, Value chan string
+	}
+	SetTagOutput struct {
+		Ret0 chan metricbatcher.BatchCounterChainer
+	}
+	IncrementCalled chan bool
+	AddCalled       chan bool
+	AddInput        struct {
+		Value chan uint64
+	}
+}
+
+func newMockBatchCounterChainer() *mockBatchCounterChainer {
+	m := &mockBatchCounterChainer{}
+	m.SetTagCalled = make(chan bool, 100)
+	m.SetTagInput.Key = make(chan string, 100)
+	m.SetTagInput.Value = make(chan string, 100)
+	m.SetTagOutput.Ret0 = make(chan metricbatcher.BatchCounterChainer, 100)
+	m.IncrementCalled = make(chan bool, 100)
+	m.AddCalled = make(chan bool, 100)
+	m.AddInput.Value = make(chan uint64, 100)
+	return m
+}
+func (m *mockBatchCounterChainer) SetTag(key, value string) metricbatcher.BatchCounterChainer {
+	m.SetTagCalled <- true
+	m.SetTagInput.Key <- key
+	m.SetTagInput.Value <- value
+	return <-m.SetTagOutput.Ret0
+}
+func (m *mockBatchCounterChainer) Increment() {
+	m.IncrementCalled <- true
+}
+func (m *mockBatchCounterChainer) Add(value uint64) {
+	m.AddCalled <- true
+	m.AddInput.Value <- value
 }


### PR DESCRIPTION
Exposing BatchCounter allows to set Tags for the metrics (similar to metric sender ValueCounter)
Related to https://github.com/cloudfoundry/routing-release/issues/445